### PR TITLE
Add feature to be able to change encoding

### DIFF
--- a/dwdatareader/__init__.py
+++ b/dwdatareader/__init__.py
@@ -15,7 +15,7 @@ __all__ = ['DWError', 'DWFile', 'getVersion']
 __version__ = '0.11.0'
 
 DLL = None # module variable accessible to other classes
-_encoding = None  # encoding
+_encoding = 'ISO-8859-1'  # encoding
 
 import os
 import collections
@@ -372,9 +372,7 @@ def unloadDLL():
     DLL = None # Release reference to DLL
 
 
-def open(source, encoding="utf-8"):
-    global _encoding
-    _encoding = encoding
+def open(source):
     return DWFile(source)
 
 

--- a/dwdatareader/__init__.py
+++ b/dwdatareader/__init__.py
@@ -15,7 +15,7 @@ __all__ = ['DWError', 'DWFile', 'getVersion']
 __version__ = '0.11.0'
 
 DLL = None # module variable accessible to other classes
-_encoding = 'ISO-8859-1'  # encoding
+encoding = 'ISO-8859-1'  # default encoding
 
 import os
 import collections
@@ -61,7 +61,7 @@ class DWEvent(ctypes.Structure):
     @property
     def event_text(self):
         """Readable description of the event"""
-        return self._event_text.decode(encoding=_encoding)
+        return self._event_text.decode(encoding=encoding)
 
     def __str__(self):
         return "{0.time_stamp} {0.event_text}".format(self)
@@ -80,17 +80,17 @@ class DWChannel(ctypes.Structure):
     @property
     def name(self):
         """An idenfitying name of the channel"""
-        return self._name.decode(encoding=_encoding)
+        return self._name.decode(encoding=encoding)
 
     @property
     def unit(self):
         """The unit of measurement used by the channel"""
-        return self._unit.decode(encoding=_encoding)
+        return self._unit.decode(encoding=encoding)
 
     @property
     def description(self):
         """A short explanation of what the channel measures"""
-        return self._description.decode(encoding=_encoding)
+        return self._description.decode(encoding=encoding)
 
     @property
     def number_of_samples(self):
@@ -237,7 +237,7 @@ class DWFile(collections.Mapping):
 
             # Open the d7d file
             self.info = DWInfo()
-            stat = DLL.DWOpenDataFile(self.name.encode(encoding=_encoding), ctypes.byref(self.info))
+            stat = DLL.DWOpenDataFile(self.name.encode(encoding=encoding), ctypes.byref(self.info))
             if stat:
                 raise DWError(stat)
             self.closed = False
@@ -264,13 +264,13 @@ class DWFile(collections.Mapping):
             stat = DLL.DWGetHeaderEntryTextF(i, text_, len(text_))
             if stat:
                 raise DWError(stat)
-            text = text_.value.decode(encoding=_encoding)
+            text = text_.value.decode(encoding=encoding)
             if len(text) and not(text.startswith('Select...') or 
                     text.startswith('To fill out')):
                 stat = DLL.DWGetHeaderEntryNameF(i, name_, len(name_))
                 if stat:
                     raise DWError(stat)
-                h[name_.value.decode(encoding=_encoding)] = text
+                h[name_.value.decode(encoding=encoding)] = text
         return h
 
     def events(self):

--- a/dwdatareader/__init__.py
+++ b/dwdatareader/__init__.py
@@ -14,11 +14,13 @@ with dw.open('myfile.d7d') as f:
 __all__ = ['DWError', 'DWFile', 'getVersion']
 __version__ = '0.11.0'
 
-DLL = None # module variable accessible to other classes 
+DLL = None # module variable accessible to other classes
+_encoding = None  # encoding
 
 import os
 import collections
 import ctypes
+
 
 class DWError(RuntimeError):
     """Interpret error number returned from dll"""
@@ -59,7 +61,7 @@ class DWEvent(ctypes.Structure):
     @property
     def event_text(self):
         """Readable description of the event"""
-        return self._event_text.decode()
+        return self._event_text.decode(encoding=_encoding)
 
     def __str__(self):
         return "{0.time_stamp} {0.event_text}".format(self)
@@ -78,17 +80,17 @@ class DWChannel(ctypes.Structure):
     @property
     def name(self):
         """An idenfitying name of the channel"""
-        return self._name.decode()
+        return self._name.decode(encoding=_encoding)
 
     @property
     def unit(self):
         """The unit of measurement used by the channel"""
-        return self._unit.decode()
+        return self._unit.decode(encoding=_encoding)
 
     @property
     def description(self):
         """A short explanation of what the channel measures"""
-        return self._description.decode()
+        return self._description.decode(encoding=_encoding)
 
     @property
     def number_of_samples(self):
@@ -235,7 +237,7 @@ class DWFile(collections.Mapping):
 
             # Open the d7d file
             self.info = DWInfo()
-            stat = DLL.DWOpenDataFile(self.name.encode(), ctypes.byref(self.info))
+            stat = DLL.DWOpenDataFile(self.name.encode(encoding=_encoding), ctypes.byref(self.info))
             if stat:
                 raise DWError(stat)
             self.closed = False
@@ -262,13 +264,13 @@ class DWFile(collections.Mapping):
             stat = DLL.DWGetHeaderEntryTextF(i, text_, len(text_))
             if stat:
                 raise DWError(stat)
-            text = text_.value.decode()
+            text = text_.value.decode(encoding=_encoding)
             if len(text) and not(text.startswith('Select...') or 
                     text.startswith('To fill out')):
                 stat = DLL.DWGetHeaderEntryNameF(i, name_, len(name_))
                 if stat:
                     raise DWError(stat)
-                h[name_.value.decode()] = text
+                h[name_.value.decode(encoding=_encoding)] = text
         return h
 
     def events(self):
@@ -370,10 +372,11 @@ def unloadDLL():
     DLL = None # Release reference to DLL
 
 
-def open(source):
+def open(source, encoding="utf-8"):
+    global _encoding
+    _encoding = encoding
     return DWFile(source)
 
 
 # Load and initialize the DLL
 loadDLL()
-

--- a/tests.py
+++ b/tests.py
@@ -110,13 +110,15 @@ class TestDW(unittest.TestCase):
 
     def test_encoding_uft8(self):
         """ Check that encoding is set correcly """
-        with dw.open(self.d7dname, encoding="utf-8") as d7d:
+        dw._encoding = 'utf-8'
+        with dw.open(self.d7dname) as d7d:
             self.assertFalse(d7d.closed, 'd7d did not open')
 
     def test_encoding_uft32(self):
         """ Check that wrong encoding raises an error """
+        dw._encoding = 'utf-32'
         with self.assertRaises(dw.DWError):
-            dw.open(self.d7dname, encoding="utf-32")
+            dw.open(self.d7dname)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -40,7 +40,7 @@ class TestDW(unittest.TestCase):
             self.assertEqual(100, d7d.info.sample_rate)
 
     def test_filelike(self):
-        """Test modeule access and usage of filelike objects.
+        """Test module access and usage of filelike objects.
 
         In this test the dw module must create a temporary file copy
         of the d7d filelike object so that the dll will have something to
@@ -107,6 +107,16 @@ class TestDW(unittest.TestCase):
         with dw.open(self.d7dname) as d7d:
             self.assertFalse(d7d.closed, 'd7d did not open')
             self.assertEqual((18771, 20), d7d.dataframe().shape)
+
+    def test_encoding_uft8(self):
+        """ Check that encoding is set correcly """
+        with dw.open(self.d7dname, encoding="utf-8") as d7d:
+            self.assertFalse(d7d.closed, 'd7d did not open')
+
+    def test_encoding_uft32(self):
+        """ Check that wrong encoding raises an error """
+        with self.assertRaises(dw.DWError):
+            dw.open(self.d7dname, encoding="utf-32")
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -110,13 +110,13 @@ class TestDW(unittest.TestCase):
 
     def test_encoding_uft8(self):
         """ Check that encoding is set correcly """
-        dw._encoding = 'utf-8'
+        dw.encoding = 'utf-8'
         with dw.open(self.d7dname) as d7d:
             self.assertFalse(d7d.closed, 'd7d did not open')
 
     def test_encoding_uft32(self):
         """ Check that wrong encoding raises an error """
-        dw._encoding = 'utf-32'
+        dw.encoding = 'utf-32'
         with self.assertRaises(dw.DWError):
             dw.open(self.d7dname)
 


### PR DESCRIPTION
Problem to fix : encoding issue
--------------------------------------
I experienced encoding issues with d7d files which names included characters like : é è ... (sorry but I'm french ;-))
The only way for me to fix the problem was to change the encoding to ISO-8859-1 in the decode/encode methods.

In fact, dwdatareader default encoding is UTF-8. According to decode()/encode() documentation, when no encoding is specified, default encoding is UTF-8.

dwdareader API does not expose a parameter to change default encoding.

My pull request proposal is to modify dwdatareader API to be able to change the encoding.

Proposed solution
-----------------------
I have added a global variable named _encoding.

Perhaps it is not the more appropriate way to share encoding between classes but it seems to be the simplest way as the code base is very small. 
Adding a new class to share encoding between classes seems to be overkilled.

Further more I added two tests to check that encoding parameter works correctly.

Could you please review my code and tell me if it seems allright to fix encoding issues ?

Thank you,

bmanjal