### PR TITLE
Bindings for DWGetChannelProps

### DIFF
--- a/dwdatareader/__init__.py
+++ b/dwdatareader/__init__.py
@@ -20,7 +20,6 @@ encoding = 'ISO-8859-1'  # default encoding
 import os
 import collections
 import ctypes
-from enum import Enum
 
 
 class DWError(RuntimeError):
@@ -100,7 +99,7 @@ class DWChannel(ctypes.Structure):
     def _chan_prop_int(self, chan_prop):
         count = ctypes.c_int(ctypes.sizeof(ctypes.c_int))
         stat = DLL.DWGetChannelProps(
-            self.index, ctypes.c_int(chan_prop.value), ctypes.byref(count),
+            self.index, ctypes.c_int(chan_prop), ctypes.byref(count),
             ctypes.byref(count))
         if stat:
             raise DWError(stat)
@@ -110,7 +109,7 @@ class DWChannel(ctypes.Structure):
         len_str = self._chan_prop_int(chan_prop_len)
         p_buff = ctypes.create_string_buffer(len_str.value)
         stat = DLL.DWGetChannelProps(
-            self.index, ctypes.c_int(chan_prop.value), p_buff,
+            self.index, ctypes.c_int(chan_prop), p_buff,
             ctypes.byref(len_str))
         if stat:
             raise DWError(stat)
@@ -223,7 +222,7 @@ class DWChannel(ctypes.Structure):
         return ax
 
 
-class DWChannelProps(Enum):
+class DWChannelProps():
     DW_DATA_TYPE = 0
     DW_DATA_TYPE_LEN_BYTES = 1
     DW_CH_INDEX = 2

--- a/tests.py
+++ b/tests.py
@@ -6,10 +6,12 @@ Execute with:
 """
 
 import unittest
+import xml.etree.ElementTree as et
 
 import pandas as pd
 
 import dwdatareader as dw
+
 
 class TestDW(unittest.TestCase):
     def setUp(self):
@@ -93,6 +95,35 @@ class TestDW(unittest.TestCase):
             actual = pd.concat(list(channel.series_generator(500)))
             actual = actual.iloc[:nos]
             self.assertTrue(actual.equals(expected))
+
+    def test_channel_type(self):
+        """Channel type"""
+        with dw.open(self.d7dname) as d7d:
+            self.assertFalse(d7d.closed, 'd7d did not open')
+            channel = d7d['ENG_RPM']
+            actual = channel.channel_type
+            expected = 1
+            self.assertEqual(actual, expected)
+
+    def test_channel_index(self):
+        """Channel type"""
+        with dw.open(self.d7dname) as d7d:
+            self.assertFalse(d7d.closed, 'd7d did not open')
+            channel = d7d['ENG_RPM']
+            actual = channel.channel_index
+            expected = 'CAN;0;640'
+            self.assertEqual(actual, expected)
+
+    def test_channel_xml(self):
+        """Channel type"""
+        with dw.open(self.d7dname) as d7d:
+            self.assertFalse(d7d.closed, 'd7d did not open')
+            channel = d7d['ENG_RPM']
+            xml = channel.channel_xml
+            root = et.fromstring(xml)
+            actual = root.find('ForceSinglePrecision').text
+            expected = 'True'
+            self.assertEqual(actual, expected)
 
     def test_reduced(self):
         """Read reduced channel data and check value."""


### PR DESCRIPTION
Bindings for channel type, index and xml.

* `dwdatareader/__init__.py` (DWChannel):  One DWChannel property per C
  API channel property.  Helper functions for C acrobatics.
* `dwdatareader/__init__.py` (DWChannelProps):  Enum mirroring the C API
  enum
* `tests.py` (TestDW.test_channel_type, TestDW.test_channel_index,
  TestDW.test_channel_xml):  Tests for channel properties

Closes #9