### PR TITLE
Expose DWExportHeader API function

### DIFF
--- a/dwdatareader/__init__.py
+++ b/dwdatareader/__init__.py
@@ -324,11 +324,12 @@ class DWFile(collections.Mapping):
                 h[name_.value.decode(encoding=encoding)] = text
         return h
 
-    def export_header(self):
+    def export_header(self, file_name):
         """Export header as .xml file"""
         self.activate()
-        file_name = "local.xml"
-        DLL.DWExportHeader(file_name.encode(encoding=encoding))
+        stat = DLL.DWExportHeader(file_name.encode(encoding=encoding))
+        if stat:
+            raise DWError(stat)
         return 0
 
     def events(self):

--- a/dwdatareader/__init__.py
+++ b/dwdatareader/__init__.py
@@ -324,6 +324,13 @@ class DWFile(collections.Mapping):
                 h[name_.value.decode(encoding=encoding)] = text
         return h
 
+    def export_header(self):
+        """Export header as .xml file"""
+        self.activate()
+        file_name = "local.xml"
+        DLL.DWExportHeader(file_name.encode(encoding=encoding))
+        return 0
+
     def events(self):
         """Load and return timeseries of file events"""
         import pandas

--- a/tests.py
+++ b/tests.py
@@ -76,8 +76,9 @@ class TestDW(unittest.TestCase):
 
     def test_export_header(self):
         """Make sure header is exported to file local.xml"""
+        file_name = "local.xml"
         with dw.open(self.d7dname) as dwf:
-            dwf.export_header()
+            dwf.export_header(file_name)
         assert os.path.isfile("local.xml")
 
     def test_events(self):

--- a/tests.py
+++ b/tests.py
@@ -74,6 +74,12 @@ class TestDW(unittest.TestCase):
             # Unfortunately, no headers in sample file
             self.assertDictEqual({}, d7d.header)
 
+    def test_export_header(self):
+        """Make sure header is exported to file local.xml"""
+        with dw.open(self.d7dname) as dwf:
+            dwf.export_header()
+        assert os.path.isfile("local.xml")
+
     def test_events(self):
         """Make sure events are readable."""
         with dw.open(self.d7dname) as d7d:


### PR DESCRIPTION
Minimalistic wrapper around DWExportHeader from the DWDataReader
API. The file name "local.xml" was chosen since it mirrors the name
DEWESoft gives the XML file when unzipping a d7s or dxs setup file.

* `dwdatareader/__init__.py` (DWFile.export_header): Wrap DWExportHeader
  API function.
* `tests.py` (test_export_header): Assert that the XML file has been
  exported with the conventional name.