### PR TITLE
Add Travis and Appveyor CI badges

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -37,9 +37,6 @@ environment:
     - PYTHON_VERSION: "3.6"
       MINICONDA: C:\Miniconda36-x64
 
-# all our python builds have to happen in tests_script...
-build: false
-
 init:
   - "ECHO %PYTHON_VERSION% %MINICONDA%"
 
@@ -57,6 +54,8 @@ install:
   - conda config --add channels conda-forge
   - conda info -a
   - "conda create --quiet --name test-environment python=%PYTHON_VERSION% pandas --file requirements.txt --file requirements-dev.txt"
+
+build: off
 
 test_script:
   - activate test-environment

--- a/README.rst
+++ b/README.rst
@@ -1,12 +1,13 @@
 dwdatareader
 ============
 
-.. image:: https://travis-ci.org/fleimgruber/dwdatareader.svg?branch=master
-  :target: https://travis-ci.org/fleimgruber/dwdatareader
+.. image:: https://travis-ci.com/costerwi/dwdatareader.svg?branch=master
+   :alt: DWDataReader build status on Travis CI
+   :target: https://travis-ci.com/costerwi/dwdatareader
 
-.. image:: https://ci.appveyor.com/api/projects/status/ivli8i8x7tdlkd5x?svg=true
+.. image:: https://ci.appveyor.com/api/projects/status/a2qssrmuepbx224i/branch/master?svg=true
    :alt: DWDataReader build status on Appveyor
-   :target: https://ci.appveyor.com/project/fleimgruber/dwdatareader/branch/master
+   :target: https://ci.appveyor.com/project/costerwi/dwdatareader/branch/master
 
 DEWESoft produces hardware and software for test measurement, data aquisition, 
 and storage. Data files are stored with the extension .d7d in a proprietary

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,13 @@
 dwdatareader
 ============
 
+.. image:: https://travis-ci.org/fleimgruber/dwdatareader.svg?branch=master
+  :target: https://travis-ci.org/fleimgruber/dwdatareader
+
+.. image:: https://ci.appveyor.com/api/projects/status/ivli8i8x7tdlkd5x?svg=true
+   :alt: DWDataReader build status on Appveyor
+   :target: https://ci.appveyor.com/project/fleimgruber/dwdatareader/branch/master
+
 DEWESoft produces hardware and software for test measurement, data aquisition, 
 and storage. Data files are stored with the extension .d7d in a proprietary
 format. DEWESoft provides a free Windows application to work with the data


### PR DESCRIPTION
Travis and Appveyor CI badges. If this gets merged, the URLs in the badges would need to be adapted (s/fleimgruber/costerwi). See my branch for how it looks like (badges below title in README.rst): https://github.com/fleimgruber/dwdatareader/tree/ci_badges.

Also note that this contains a fix for Appveyor https://ci.appveyor.com/project/costerwi/dwdatareader/builds/30347604 which works for my project https://ci.appveyor.com/project/fleimgruber/dwdatareader/builds/30663653.