### PR TITLE
Do not call DWAddReader unless required

### DIFF
--- a/dwdatareader/__init__.py
+++ b/dwdatareader/__init__.py
@@ -12,7 +12,7 @@ with dw.open('myfile.d7d') as f:
         print(ch.name, ch.series().mean())
 """
 __all__ = ['DWError', 'DWFile', 'getVersion']
-__version__ = '0.12.0'
+__version__ = '0.12.1'
 
 DLL = None # module variable accessible to other classes
 encoding = 'ISO-8859-1'  # default encoding


### PR DESCRIPTION
I was getting DLL errors when attempting to call DLL.DWGetArrayInfoCount() before other methods, such as dw.events().

Eventually I traced it back to the poor handling of the active file reader. This update seems to fix the problem. 