### PR TITLE
Channel arrays

### DIFF
--- a/dwdatareader/__init__.py
+++ b/dwdatareader/__init__.py
@@ -95,7 +95,11 @@ class DWChannel(ctypes.Structure):
 
     @property
     def number_of_samples(self):
-        return DLL.DWGetScaledSamplesCount(self.index)
+        count = DLL.DWGetScaledSamplesCount(self.index)
+        if count < 0:
+            raise IndexError('DWGetScaledSamplesCount({})={} should be non-negative'.format(
+                self.index, count))
+        return count
 
     def _chan_prop_int(self, chan_prop):
         count = ctypes.c_int(ctypes.sizeof(ctypes.c_int))
@@ -139,10 +143,7 @@ class DWChannel(ctypes.Structure):
         import pandas
         if not 0 <= arrayIndex < self.array_size:
             raise IndexError('arrayIndex is out of range')
-        count = DLL.DWGetScaledSamplesCount(self.index)
-        if count < 0:
-            raise IndexError('DWGetScaledSamplesCount({})={} should be non-negative'.format(
-                self.index, count))
+        count = self.number_of_samples
         data = numpy.empty(count*self.array_size, dtype=numpy.double)
         time = numpy.empty(count, dtype=numpy.double)
         stat = DLL.DWGetScaledSamples(self.index, ctypes.c_int64(0), count,

--- a/tests.py
+++ b/tests.py
@@ -139,6 +139,13 @@ class TestDW(unittest.TestCase):
             r5 = r.ave.asof(5.0) # index into reduced list near time=5.0
             self.assertTrue(abs(r5 - 3099.7) < 1)
 
+    def test_channel_dataframe(self):
+        """Read one channel as a DataFrame"""
+        with dw.open(self.d7dname) as d7d:
+            self.assertFalse(d7d.closed, 'd7d did not open')
+            df = d7d['ENG_RPM'].dataframe()
+            self.assertEqual(len(df.ENG_RPM), 4791)
+
     def test_dataframe(self):
         """Read all channel data as a single DataFrame."""
         with dw.open(self.d7dname) as d7d:
@@ -156,6 +163,7 @@ class TestDW(unittest.TestCase):
         dw.encoding = 'utf-32'
         with self.assertRaises(dw.DWError):
             dw.open(self.d7dname)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Provide some support for channel arrays (also known as channel axis) #21 

The property DWChannel.arrayInfo has been added which returns a list of DWArrayInfo for the given channel.

A new method DWChannel.dataframe() has been added to retrieve all array data for the given channel. It also works for channels without array data.

Example usage:
```python
d7dname = 'dwdatareader_I_Pst_sample.d7d'
with dw.open(d7dname) as d7d:
    for ch in d7d.channels:
        if ch.array_size > 1:
            print(ch.name, ch.index, ch.array_size)
            for axis in ch.arrayInfo:
                print(axis)
            print(ch.dataframe())
```