### PR TITLE
Add local.xml test artifact to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Test artifacts
+local.xml


### PR DESCRIPTION
The `test_export_header` test creates a "local.xml" file. Add this file to the gitignore to untrack it from version control.