### PR TITLE
Remove `is` check with string literal

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -115,7 +115,7 @@ class TestDW(unittest.TestCase):
             self.assertEqual(actual, expected)
 
     @pytest.mark.skipif((platform.architecture()[0] == '32bit')
-                        or (os.name is not 'nt')
+                        or (os.name != 'nt')
                         or (sys.version_info >= (3, 5)),
                         reason='Upstream bug.')
     def test_channel_index(self):


### PR DESCRIPTION
Running "tests.py" with the latest version of Python throws the syntax warning:

```
SyntaxWarning: "is not" with a literal. Did you mean "!="?
  or (os.name is not 'nt')
```

So following the compiler's advice, change this check to a simple `!=`.

See here for more info:
https://adamj.eu/tech/2020/01/21/why-does-python-3-8-syntaxwarning-for-is-literal/