### PR TITLE
Use `Mapping` from `collections.abc` instead of `collections`

### DIFF
--- a/dwdatareader/__init__.py
+++ b/dwdatareader/__init__.py
@@ -18,9 +18,12 @@ DLL = None # module variable accessible to other classes
 encoding = 'ISO-8859-1'  # default encoding
 
 import os
-import collections
 import ctypes
 
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 
 class DWError(RuntimeError):
     """Interpret error number returned from dll"""
@@ -319,7 +322,7 @@ class DWChannelProps():
     DW_CH_XMLPROPS_LEN = 10
 
 
-class DWFile(collections.Mapping):
+class DWFile(Mapping):
     """Data file type mapping channel names their metadata"""
 
     _readers = [] # Internal list of DWFile instances


### PR DESCRIPTION
Running the library from the latest version of Python gives the following deprecation warning:

```
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
  class DWFile(collections.Mapping):
```

So use `Mapping` from the `abc` module instead.