### PR TITLE
feat: Support complex number channels in existing API

### DIFF
--- a/dwdatareader/__init__.py
+++ b/dwdatareader/__init__.py
@@ -17,6 +17,7 @@ __version__ = '0.16.0'
 DLL = None # module variable accessible to other classes
 encoding = 'ISO-8859-1'  # default encoding
 
+from enum import Enum
 import os
 import ctypes
 
@@ -24,6 +25,13 @@ try:
     from collections.abc import Mapping
 except ImportError:
     from collections import Mapping
+
+import numpy as np
+import pandas as pd
+
+class NumberType(Enum):
+    real = 0
+    complex = 1
 
 class DWError(RuntimeError):
     """Interpret error number returned from dll"""
@@ -125,14 +133,30 @@ class DWChannel(ctypes.Structure):
     def description(self):
         """A short explanation of what the channel measures"""
         return self._description.decode(encoding=encoding)
+    
+    def get_scaled_samples_count(self):
+        if self.number_type() == NumberType.complex:
+            return DLL.DWGetComplexScaledSamplesCount
+        return DLL.DWGetScaledSamplesCount
+    
+    def get_scaled_samples(self):
+        if self.number_type() == NumberType.complex:
+            return DLL.DWGetComplexScaledSamples
+        return DLL.DWGetScaledSamples
 
     @property
     def number_of_samples(self):
-        count = DLL.DWGetScaledSamplesCount(self.index)
+        count = self.get_scaled_samples_count()(self.index)
         if count < 0:
-            raise IndexError('DWGetScaledSamplesCount({})={} should be non-negative'.format(
+            raise IndexError('DWGet[Complex]ScaledSamplesCount({})={} should be non-negative'.format(
                 self.index, count))
         return count
+
+    @property
+    def dtype(self):
+        if self.number_type() == NumberType.complex:
+            return np.complex128
+        return np.double
 
     def _chan_prop_int(self, chan_prop):
         count = ctypes.c_int(ctypes.sizeof(ctypes.c_int))
@@ -210,23 +234,29 @@ class DWChannel(ctypes.Structure):
 
     def scaled(self, arrayIndex=0):
         """Load and return full speed data as Pandas Series"""
-        import numpy
-        import pandas
         if not 0 <= arrayIndex < self.array_size:
             raise IndexError('arrayIndex is out of range')
+
         count = self.number_of_samples
-        data = numpy.empty(count*self.array_size, dtype=numpy.double)
-        time = numpy.empty(count, dtype=numpy.double)
-        stat = DLL.DWGetScaledSamples(self.index, ctypes.c_int64(0), ctypes.c_int64(count),
-                data.ctypes, time.ctypes)
+        data = np.empty(count*self.array_size, dtype=self.dtype())
+        time = np.empty(count, dtype=np.double)
+        stat = self.get_scaled_samples()(
+            self.index,
+            ctypes.c_int64(0),
+            ctypes.c_int64(count),
+            data.ctypes,
+            time.ctypes,
+        )
+
         if stat:
             raise DWError(stat)
 
-        time, ix = numpy.unique(time, return_index=True) # use unique times
-        return pandas.Series(
-                data = data.reshape(count, self.array_size)[ix, arrayIndex],
-                index = time,
-                name = self.name)
+        time, ix = np.unique(time, return_index=True) # use unique times
+        return pd.Series(
+            data=data.reshape(count, self.array_size)[ix, arrayIndex],
+            index=time,
+            name=self.name,
+        )
 
     def dataframe(self):
         """Load and return full speed channel data as Pandas Dataframe"""
@@ -294,6 +324,11 @@ class DWChannel(ctypes.Structure):
 
         return pandas.DataFrame(data, index=data['time_stamp'],
                 columns=['ave', 'min', 'max', 'rms'])
+    
+    def number_type(self) -> NumberType:
+        if self.data_type in [9, 10]:
+            return NumberType.complex
+        return NumberType.real
 
     def series(self):
         """Load and return timeseries of results for channel"""
@@ -421,8 +456,16 @@ class DWFile(Mapping):
             nchannels = DLL.DWGetChannelListCount()
             self.channels = (DWChannel * nchannels)()
             stat = DLL.DWGetChannelList(self.channels)
+
+            nchannels_complex = DLL.DWGetComplexChannelListCount()
+            self.channels_complex = (DWChannel * nchannels_complex)()
+            stat_complex = DLL.DWGetComplexChannelList(self.channels_complex)
+
             if stat:
                 raise DWError(stat)
+            if stat_complex:
+                raise DWError(stat_complex)
+
         except:
             self.close() # if open() fails then the file should be closed
             raise
@@ -485,6 +528,14 @@ class DWFile(Mapping):
             # Return dataframe of ALL channels by default
             channels = self.keys()
         return pandas.DataFrame({k: self[k].series() for k in channels})
+
+    def dataframe_longname(self, channels = None):
+        """Return dataframe of selected series, long-name columns"""
+        self.activate()
+        if channels is None:
+            # Return dataframe of ALL channels by default
+            channels = self.keys()
+        return pd.DataFrame({c.long_name: c.series() for c in channels})
 
     def close(self):
         """Close the d7d file and delete it if temporary"""

--- a/test_module.py
+++ b/test_module.py
@@ -10,6 +10,7 @@ import sys
 import unittest
 import xml.etree.ElementTree as et
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -22,6 +23,8 @@ class TestDW(unittest.TestCase):
         import os
         self.d7dname = os.path.join(os.path.dirname(__file__),
                 "Example_Drive01.d7d")
+        self.complex_dxd_name = os.path.join(os.path.dirname(__file__),
+                "example_complex.dxd")
 
     def test_context(self):
         """Check that the d7d is open and closed according to context."""
@@ -132,7 +135,6 @@ class TestDW(unittest.TestCase):
             expected = 0.0
             self.assertEqual(actual, expected)
 
-
     @unittest.expectedFailure
     def test_CAN_channel(self):
         """Read channel data with CAN in its channel_index"""
@@ -206,6 +208,22 @@ class TestDW(unittest.TestCase):
         dw.encoding = 'utf-32'
         with self.assertRaises(dw.DWError):
             dw.open(self.d7dname)
+
+    def test_complex_channel_dtypes(self):
+        """Check complex channel dtypes"""
+        with dw.open(self.complex_dxd_name) as test_file:
+            self.assertFalse(test_file.closed, "dxd did not open")
+            complex_channels = [c for c in test_file.channels_complex]
+            np.testing.assert_array_equal(
+                test_file.dataframe_longname(complex_channels).dtypes.values,
+                np.array([np.dtype("complex128")] * len(complex_channels))
+            )
+
+    def test_complex_channel_shape(self):
+        """Check complex channel shape"""
+        with dw.open(self.complex_dxd_name) as test_file:
+            complex_channels = [c for c in test_file.channels_complex]
+            self.assertEqual(test_file.dataframe_longname(complex_channels).shape, (184, 33))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This tries to keep to the existing APIs as closely as possible.

I could not find a way to reconcile `DWFile.channels` and `DWFile.complex_channels`. This is also the reason why the key access in the existing `dataframe()` did not work and I had to resort to adding `dataframe_longname()` which uses the channel "long-names", as was mentioned in https://github.com/costerwi/dwdatareader/pull/71#discussion_r2254353614. The included test file also has example channels for testing the uniqueness so could also help in that activity. Happy to rework this part of the PR after review and a final decision.

Using `Enum` to distiguish between real and complex channels.

closes #67