### PR TITLE
Fix mutable defaults and buffer reuse in data reader

### DIFF
--- a/dwdatareader/__init__.py
+++ b/dwdatareader/__init__.py
@@ -553,9 +553,9 @@ class DWBinaryChannel(DWChannel):
         if status: raise DWError(status)
 
         bin_data = []
-        bin_buf = ctypes.create_string_buffer(1024)
-        bin_buf_pos = ctypes.c_longlong(0)
         for bin_rec in bin_samples:
+            bin_buf = ctypes.create_string_buffer(1024)
+            bin_buf_pos = ctypes.c_longlong(0)
             status = DLL.DWIGetBinData(
                 self.dwFile.reader_handle, self.index,
                 ctypes.byref(bin_rec), ctypes.byref(bin_buf),

--- a/dwdatareader/__init__.py
+++ b/dwdatareader/__init__.py
@@ -567,7 +567,6 @@ class DWBinaryChannel(DWChannel):
         # Return as a Pandas DataFrame
         return pd.DataFrame({self.unique_key: bin_data}, index=np.array(timestamps))
 
-
 class DWComplexChannel(DWChannel):
     "Represents a complex data channel, providing methods to access its data."
 
@@ -604,7 +603,6 @@ class DWComplexChannel(DWChannel):
         )
         if status: raise DWError(status)
         return time, data
-
 
 class DWDataType(IntEnum):
     """Specifies the channel data type."""
@@ -937,7 +935,6 @@ class DWMeasurementInfo(ctypes.Structure):
     def start_measure_time(self):
         """Return start_store_time in Python datetime format"""
         return self.epoch + timedelta(self._start_measure_time)
-
 
 class DWStatus(IntEnum):
     """Status codes returned from library function calls"""

--- a/dwdatareader/__init__.py
+++ b/dwdatareader/__init__.py
@@ -847,7 +847,10 @@ class DWFile(dict):
                 data = {'type': event_type, 'text': event_text},
                 index = time_stamp)
 
-    def _build_dataframe(self, channels: List = []) -> pd.DataFrame:
+    def _build_dataframe(self, channels: List = None) -> pd.DataFrame:
+        if channels is None:
+            channels = []
+
         if not channels:
             return pd.DataFrame()
 
@@ -860,8 +863,12 @@ class DWFile(dict):
                 df = df.drop(columns=['key_0'])
         return df
 
-    def _assemble_channels(self, channels: List[str], ignore_channels: List[str] = [], ch_type: Optional[DWChannelType] = None) -> List[str]:
+    def _assemble_channels(self, channels: List[str], ignore_channels: List[str] = None,
+                           ch_type: Optional[DWChannelType] = None) -> List[str]:
         """Filter channels according to optional criteria"""
+        if channels is None:
+            channels = []
+
         if not channels:
             # Return dataframe of all channels by default
             channels = list(self.keys())
@@ -873,15 +880,33 @@ class DWFile(dict):
 
         return channels
 
-    def dataframe(self, channels: List[str] = [], ignore_channels: List[str] = []) -> pd.DataFrame:
+    def dataframe(self, channels: List[str] = None, ignore_channels: List[str] = None) -> pd.DataFrame:
+        if channels is None:
+            channels = []
+
+        if ignore_channels is None:
+            ignore_channels = []
+
         channels = self._assemble_channels(channels, ignore_channels)
         return self._build_dataframe(channels)
 
-    def sync_dataframe(self, channels: List[str] = [], ignore_channels: List[str] = []) -> pd.DataFrame:
+    def sync_dataframe(self, channels: List[str] = None, ignore_channels: List[str] = None) -> pd.DataFrame:
+        if channels is None:
+            channels = []
+
+        if ignore_channels is None:
+            ignore_channels = []
+
         channels = self._assemble_channels(channels, ignore_channels, DWChannelType.DW_CH_TYPE_SYNC)
         return self._build_dataframe(channels)
 
-    def async_dataframe(self, channels: List[str] = [], ignore_channels: List[str] = []) -> pd.DataFrame:
+    def async_dataframe(self, channels: List[str] = None, ignore_channels: List[str] = None) -> pd.DataFrame:
+        if channels is None:
+            channels = []
+
+        if ignore_channels is None:
+            ignore_channels = []
+
         channels = self._assemble_channels(channels, ignore_channels, DWChannelType.DW_CH_TYPE_ASYNC)
         return self._build_dataframe(channels)
 

--- a/dwdatareader/__init__.py
+++ b/dwdatareader/__init__.py
@@ -14,14 +14,14 @@ with dw.DWFile('myfile.d7d') as f:
 __all__ = ['get_version', 'open_file', 'DWError', 'DWFile']
 __version__ = '1.2.0'
 
+import atexit
 import ctypes
 import platform
-import atexit
 from datetime import datetime, timezone, timedelta
-from pathlib import Path
 from enum import IntEnum
-from xml.etree import ElementTree
+from pathlib import Path
 from typing import Any, Callable, List, Tuple, Optional
+from xml.etree import ElementTree
 
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
This PR mostly fixes a few behavior issues, but also cleans up code style a bit. It removes mutable default arguments by switching to None and initializing empty lists inside the methods, which prevents shared state across repeated calls. It also moves the binary buffer allocation inside the loop so each record gets a fresh buffer instead of accidentally reusing one (this bug has lead to data corruption on one of my pipelines). Finally, it trims a few unnecessary blank lines between class definitions for consistent readability.